### PR TITLE
05_IgnoreBinDir

### DIFF
--- a/runAll.sh
+++ b/runAll.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-BASEDIR=$(cd "$(dirname $(readlink -e $0))/../" && pwd )
+BASEDIR=$(cd "$(dirname $(readlink -e $0))" && pwd )
 
 
-bash ${BASEDIR}/bin/buildDataTree.sh
-bash ${BASEDIR}/bin/getMercado.sh
-bash ${BASEDIR}/bin/getTemporada.sh
-bash ${BASEDIR}/bin/getSuperManagerMerged.sh -y
+bash ${BASEDIR}/buildDataTree.sh
+bash ${BASEDIR}/getMercado.sh
+bash ${BASEDIR}/getTemporada.sh
+bash ${BASEDIR}/getSuperManagerMerged.sh -y


### PR DESCRIPTION
Refiere los ejecutables a la ubicación del propio script sin necesidad de bin
